### PR TITLE
adds server to interaction tests and read me

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,98 @@ end
 `mqtt_server` provides a server behaviour for MQTT. A server would implement the `mqtt_server` behaviour, and would then
 be able to accept MQTT connections from clients. Currently this server only supports QoS 0 messages.
 
+### Example Elixir server usage
+
+Application:
+
+```elixir
+defmodule MyMQTTServer.Application do
+  use Application
+
+  def start(_type, _args) do
+    opts = [
+      strategy: :one_for_one,
+      name: MyMQTTServer.Supervisor
+    ]
+
+    children = [
+      :ranch.child_spec(
+        :my_mqtt_server,
+        :ranch_tcp,
+        [{:port, 1883}],
+        MyMQTTServer.Connection,
+        []
+      )
+    ]
+
+    Supervisor.start_link(children, opts)
+  end
+end
+```
+
+Connection:
+
+```elixir
+defmodule MyMQTTServer.Connection do
+  use MQTT.Server
+
+  def start_link(ref, ranch_socket, ranch_transport, options) do
+    :proc_lib.start_link(__MODULE__, :init, [ref, ranch_socket, ranch_transport, options])
+  end
+
+  def stop(pid) do
+    MQTT.Server.stop(pid, :normal, 500)
+  end
+
+  def init(ref, ranch_socket, ranch_transport, _options) do
+    :ok = :proc_lib.init_ack({:ok, self()})
+    :ok = :ranch.accept_ack(ref)
+    transport = MQTT.Transport.new(ranch_transport.name(), ranch_socket)
+    MQTT.Server.enter_loop(__MODULE__, [], transport)
+  end
+
+  def init(_args, %{protocol: <<"MQTT">>}) do
+    {:ok, :my_state}
+  end
+
+  def init(_args, _) do
+    {:stop, :unacceptable_protocol}
+  end
+
+  def handle_publish(_topic, _msg, _opts, state) do
+    {:ok, state}
+  end
+
+  def handle_subscribe(_topic, _qos, state) do
+    {:ok, :failed, state}
+  end
+
+  def handle_unsubscribe(_topic, state) do
+    {:ok, state}
+  end
+
+  def handle_call(msg, from, state) do
+    {:ok, state, {:reply, from, {:error, {:bad_call, msg}}}}
+  end
+
+  def handle_info(msg, state) do
+    {:ok, state}
+  end
+
+  def handle_cast(msg, state) do
+    {:ok, state}
+  end
+
+  def terminate(_reason, _state) do
+    :ok
+  end
+
+  def code_change(_old, state, _extra) do
+    {:ok, state}
+  end
+end
+```
+
 ## TODO
 
 ### Add support for QoS 1 and 2

--- a/mix.exs
+++ b/mix.exs
@@ -8,6 +8,7 @@ defmodule MQTT.Mixfile do
       version: "0.3.0",
       elixir: "~> 1.6",
       package: package(),
+      elixirc_paths: elixirc_paths(Mix.env()),
       description: "Erlang/Elixir low level MQTT protocol implementation",
       source_url: "https://github.com/kopera/erlang-mqtt",
       deps: deps()
@@ -20,6 +21,9 @@ defmodule MQTT.Mixfile do
       registered: [:mqtt_sup, :mqtt_client_sup],
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   defp package() do
     [
@@ -44,7 +48,8 @@ defmodule MQTT.Mixfile do
     [
       {:ex_doc, "~> 0.18.3", only: :dev, runtime: false},
       {:dialyxir, "~> 0.5.1", only: [:dev, :test], runtime: false},
-      {:credo, "~> 0.8.10", only: [:dev, :test], runtime: false}
+      {:credo, "~> 0.8.10", only: [:dev, :test], runtime: false},
+      {:ranch, "~> 1.5.0", only: [:dev, :test], runtime: false}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -4,4 +4,5 @@
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "ranch": {:hex, :ranch, "1.5.0", "f04166f456790fee2ac1aa05a02745cc75783c2bfb26d39faf6aefc9a3d3a58a", [], [], "hexpm"},
 }

--- a/test/client/interaction_test.exs
+++ b/test/client/interaction_test.exs
@@ -5,7 +5,11 @@ defmodule MQTT.Client.IntegrationTest do
   use ExUnit.Case
   alias MQTT.Client
 
-  @tag :external
+  setup do
+    server = start_supervised!(TestServer.ranch_listner())
+    %{server: server}
+  end
+
   test "Client should handle publish and subscribe" do
     {:ok, connection, false} = Client.connect(%{
       transport: {:tcp, %{host: "localhost"}}
@@ -22,7 +26,6 @@ defmodule MQTT.Client.IntegrationTest do
     :ok = Client.disconnect(connection)
   end
 
-  @tag :external
   test "Client should support Last Will and Testament" do
     lwt_topic = "/last/will"
     lwt_message = "Goodbye cruel World!"

--- a/test/client/interaction_test.exs
+++ b/test/client/interaction_test.exs
@@ -6,8 +6,9 @@ defmodule MQTT.Client.IntegrationTest do
   alias MQTT.Client
 
   setup do
-    server = start_supervised!(TestServer.ranch_listner())
-    %{server: server}
+    ranch_sup = start_supervised!(TestServer.ranch_sup())
+    ranch_listner_sup = start_supervised!(TestServer.ranch_listner_sup())
+    %{ranch_sup: ranch_sup, ranch_listner_sup: ranch_listner_sup}
   end
 
   test "Client should handle publish and subscribe" do

--- a/test/support/test_server.ex
+++ b/test/support/test_server.ex
@@ -8,19 +8,43 @@ defmodule TestServer do
     ]
 
     children = [
-      ranch_listner()
+      ranch_sup(),
+      ranch_listner_sup()
     ]
 
     Supervisor.start_link(children, opts)
   end
 
-  def ranch_listner() do
-    :ranch.child_spec(
-      :test_server,
-      :ranch_tcp,
-      [{:port, 1883}],
-      TestServer.Connection,
-      []
-    )
+  def ranch_sup() do
+    %{
+      id: :ranch_sup,
+      start: {:ranch_sup, :start_link, []}
+    }
+  end
+
+  def ranch_listner_sup() do
+    ref = :test_server
+    num_acceptors = 10
+    ranch_module = :ranch_tcp
+    transport_opts = [{:port, 1883}]
+    proto_opts = []
+
+    %{
+      id: {:ranch_listener_sup, ref},
+      start:
+        {:ranch_listener_sup, :start_link,
+         [
+           ref,
+           num_acceptors,
+           ranch_module,
+           transport_opts,
+           TestServer.Connection,
+           proto_opts
+         ]},
+      restart: :permanent,
+      shutdown: :infinity,
+      type: :supervisor,
+      modules: [:ranch_listener_sup]
+    }
   end
 end

--- a/test/support/test_server.ex
+++ b/test/support/test_server.ex
@@ -1,0 +1,26 @@
+defmodule TestServer do
+  use Application
+
+  def start(_type, _args) do
+    opts = [
+      strategy: :one_for_one,
+      name: TestServer.Supervisor
+    ]
+
+    children = [
+      ranch_listner()
+    ]
+
+    Supervisor.start_link(children, opts)
+  end
+
+  def ranch_listner() do
+    :ranch.child_spec(
+      :test_server,
+      :ranch_tcp,
+      [{:port, 1883}],
+      TestServer.Connection,
+      []
+    )
+  end
+end

--- a/test/support/test_server/connection.ex
+++ b/test/support/test_server/connection.ex
@@ -28,8 +28,8 @@ defmodule TestServer.Connection do
     {:ok, state}
   end
 
-  def handle_subscribe(_topic, _qos, state) do
-    {:ok, :failed, state}
+  def handle_subscribe(topic, qos, state) do
+    {:ok, qos, state}
   end
 
   def handle_unsubscribe(_topic, state) do

--- a/test/support/test_server/connection.ex
+++ b/test/support/test_server/connection.ex
@@ -1,0 +1,58 @@
+defmodule TestServer.Connection do
+  use MQTT.Server
+
+  def start_link(ref, ranch_socket, ranch_transport, options) do
+    :proc_lib.start_link(__MODULE__, :init, [ref, ranch_socket, ranch_transport, options])
+  end
+
+  def stop(pid) do
+    MQTT.Server.stop(pid, :normal, 500)
+  end
+
+  def init(ref, ranch_socket, ranch_transport, _options) do
+    :ok = :proc_lib.init_ack({:ok, self()})
+    :ok = :ranch.accept_ack(ref)
+    transport = MQTT.Transport.new(ranch_transport.name(), ranch_socket)
+    MQTT.Server.enter_loop(__MODULE__, [], transport)
+  end
+
+  def init(_args, %{protocol: <<"MQTT">>}) do
+    {:ok, :my_state}
+  end
+
+  def init(_args, _) do
+    {:stop, :unacceptable_protocol}
+  end
+
+  def handle_publish(_topic, _msg, _opts, state) do
+    {:ok, state}
+  end
+
+  def handle_subscribe(_topic, _qos, state) do
+    {:ok, :failed, state}
+  end
+
+  def handle_unsubscribe(_topic, state) do
+    {:ok, state}
+  end
+
+  def handle_call(msg, from, state) do
+    {:ok, state, {:reply, from, {:error, {:bad_call, msg}}}}
+  end
+
+  def handle_info(msg, state) do
+    {:ok, state}
+  end
+
+  def handle_cast(msg, state) do
+    {:ok, state}
+  end
+
+  def terminate(_reason, _state) do
+    :ok
+  end
+
+  def code_change(_old, state, _extra) do
+    {:ok, state}
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,2 @@
-ExUnit.configure exclude: [:external, :skip]
+ExUnit.configure exclude: [:skip]
 ExUnit.start()


### PR DESCRIPTION
Using the test to document the server code.

Closes #6 

@asabil i'm having trouble with the child spec:

```
  1) test Client should support Last Will and Testament (MQTT.Client.IntegrationTest)
     test/client/interaction_test.exs:29
     ** (ArgumentError) old tuple-based child specification {{:ranch_listener_sup, :test_server}, {:ranch_listener_sup, :start_link, [:test_server, 10, :ranch_tcp, [port: 1883], TestServer.Connection, []]}, :permanent, :infinity, :supervisor, [:ranch_listener_sup]} is not supported in Supervisor.child_spec/2
     stacktrace:
       (elixir) lib/supervisor.ex:738: Supervisor.child_spec/2
       (ex_unit) lib/ex_unit/callbacks.ex:343: ExUnit.Callbacks.start_supervised/2
       (ex_unit) lib/ex_unit/callbacks.ex:352: ExUnit.Callbacks.start_supervised!/2
       test/client/interaction_test.exs:9: MQTT.Client.IntegrationTest.__ex_unit_setup_0/1
       test/client/interaction_test.exs:1: MQTT.Client.IntegrationTest.__ex_unit__/2
```

Running on:

```
Erlang/OTP 20 [erts-9.3.1] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]

Elixir 1.6.5 (compiled with OTP 20)
```

What do you think?